### PR TITLE
Enable theme-check rules

### DIFF
--- a/.theme-check.yml
+++ b/.theme-check.yml
@@ -1,4 +1,4 @@
 MatchingTranslations:
-  enabled: false
+  enabled: true
 TemplateLength:
-  enabled: false
+  enabled: true


### PR DESCRIPTION
## Summary
- enable MatchingTranslations and TemplateLength

## Testing
- `gem install theme-check --no-document` *(fails: 403 Forbidden)*
- `theme-check` *(fails: command not found)*
- `npx theme-check` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840d671a000832289e97f8ffcc1558f