### PR TITLE
Apply floating cart snippet & hero tweaks

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -16,11 +16,7 @@
   <link rel="stylesheet" href="{{ 'component-mega-menu.css' | asset_url }}" media="print" onload="this.media='all'">
 {%- endif -%}
 
-{%- comment %} RAVE CUSTOMIZATION: Add cart drawer CSS and JS {%- endcomment %}
-{%- if settings.cart_type == 'drawer' -%}
-  <link rel="stylesheet" href="{{ 'component-cart-drawer.css' | asset_url }}" media="print" onload="this.media='all'">
-  <script src="{{ 'cart-drawer.js' | asset_url }}" defer="defer"></script>
-{%- endif -%}
+
 
 <style>
   header-drawer {
@@ -351,21 +347,15 @@
 </{{ header_tag }}>
 
 {%- comment %} RAVE CUSTOMIZATION: Add floating cart icon on right side {%- endcomment %}
-<button type="button" class="rave-floating-cart" id="cart-icon-bubble" aria-haspopup="dialog">
-  {% if cart == empty %}
-    <span class="svg-wrapper">{{ 'icon-cart-empty.svg' | inline_asset_content }}</span>
-  {% else %}
-    <span class="svg-wrapper">{{ 'icon-cart.svg' | inline_asset_content }}</span>
-  {% endif %}
-  <span class="visually-hidden">{{ 'templates.cart.cart' | t }}</span>
-  {%- if cart != empty -%}
-    <div class="cart-count-bubble">
-      {%- if cart.item_count < 100 -%}
-        <span aria-hidden="true">{{ cart.item_count }}</span>
-      {%- endif -%}
-      <span class="visually-hidden">{{ 'sections.header.cart_count' | t: count: cart.item_count }}</span>
-    </div>
-  {%- endif -%}
+<button
+  type="button"
+  class="rave-floating-cart"
+  id="cart-icon-bubble"
+  aria-haspopup="dialog"
+  aria-controls="CartDrawer"
+  aria-expanded="false"
+>
+  {% render 'cart-icon-bubble' %}
 </button>
 
 {%- comment %} RAVE CUSTOMIZATION: Cart drawer is already rendered in theme.liquid, removed duplicate {%- endcomment %}

--- a/sections/main-hero.liquid
+++ b/sections/main-hero.liquid
@@ -16,9 +16,6 @@
     <a href="{{ hero_link }}" class="main-hero__link">
   {%- endif -%}
 
-  <!-- Debug info - will show in HTML comments -->
-  <!-- Video file value: {{ section.settings.video_file | json }} -->
-  <!-- Has video: {{ has_video }} -->
 
   {%- if has_video -%}
     <div class="main-hero__video-wrapper">
@@ -28,7 +25,7 @@
         loop
         muted
         playsinline
-        preload="auto"
+        preload="metadata"
         {% if section.settings.image_desktop != blank %}
           poster="{{ section.settings.image_desktop | image_url }}"
         {% endif %}
@@ -84,11 +81,11 @@
       {%- endif -%}
       <img
         src="{{ section.settings.image_desktop | image_url: width: section.settings.image_desktop.width }}"
-        alt="{{ section.settings.image_desktop.alt | escape }}"
+        alt="{{ section.settings.image_desktop.alt | default: shop.name | escape }}"
         width="{{ section.settings.image_desktop.width }}"
         height="{{ section.settings.image_desktop.height }}"
         class="main-hero__image"
-        loading="lazy"
+        loading="eager"
       >
     </picture>
   {%- else -%}

--- a/snippets/cart-icon-bubble.liquid
+++ b/snippets/cart-icon-bubble.liquid
@@ -1,0 +1,15 @@
+{% if cart == empty %}
+  <span class="svg-wrapper">{{ 'icon-cart-empty.svg' | inline_asset_content }}</span>
+{% else %}
+  <span class="svg-wrapper">{{ 'icon-cart.svg' | inline_asset_content }}</span>
+{% endif %}
+
+<span class="visually-hidden">{{ 'templates.cart.cart' | t }}</span>
+{%- if cart != empty -%}
+  <div class="cart-count-bubble">
+    {%- if cart.item_count < 100 -%}
+      <span aria-hidden="true">{{ cart.item_count }}</span>
+    {%- endif -%}
+    <span class="visually-hidden">{{ 'sections.header.cart_count' | t: count: cart.item_count }}</span>
+  </div>
+{%- endif -%}

--- a/snippets/rave-custom-footer.liquid
+++ b/snippets/rave-custom-footer.liquid
@@ -24,7 +24,6 @@
   endfor
 -%}
 
-{% stylesheet_tag 'rave-custom.css' %}
 
 <div class="rcf">
   <div class="rcf__wrapper">


### PR DESCRIPTION
## Summary
- streamline custom footer snippet
- remove redundant cart drawer assets in header
- reuse `cart-icon-bubble` snippet for floating cart button
- tune hero preload and alt text

## Testing
- `theme-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ed16b1f48322a57fd0633d40cda2