### PR TITLE
Fix complementary products flash

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -1134,6 +1134,7 @@ class ProductRecommendations extends HTMLElement {
   }
 
   connectedCallback() {
+    this.hidden = true;
     this.initializeRecommendations(this.dataset.productId);
   }
 
@@ -1152,7 +1153,10 @@ class ProductRecommendations extends HTMLElement {
 
   loadRecommendations(productId) {
     fetch(`${this.dataset.url}&product_id=${productId}&section_id=${this.dataset.sectionId}`)
-      .then((response) => response.text())
+      .then((response) => {
+        if (!response.ok) throw new Error(response.status);
+        return response.text();
+      })
       .then((text) => {
         const html = document.createElement('div');
         html.innerHTML = text;
@@ -1160,18 +1164,17 @@ class ProductRecommendations extends HTMLElement {
 
         if (recommendations?.innerHTML.trim().length) {
           this.innerHTML = recommendations.innerHTML;
-        }
-
-        if (!this.querySelector('slideshow-component') && this.classList.contains('complementary-products')) {
+          this.hidden = false;
+          if (html.querySelector('.grid__item')) {
+            this.classList.add('product-recommendations--loaded');
+          }
+        } else {
           this.remove();
-        }
-
-        if (html.querySelector('.grid__item')) {
-          this.classList.add('product-recommendations--loaded');
         }
       })
       .catch((e) => {
         console.error(e);
+        this.remove();
       });
   }
 }

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -518,6 +518,7 @@
                   data-url="{{ routes.product_recommendations_url }}?limit={{ block.settings.product_list_limit }}&intent=complementary"
                   data-section-id="{{ section.id }}"
                   data-product-id="{{ product.id }}"
+                  hidden
                 >
                   {%- if recommendations.performed and recommendations.products_count > 0 -%}
                     <aside


### PR DESCRIPTION
## Summary
- keep complementary products hidden until recommendations load
- fail gracefully if fetching product recommendations fails

## Testing
- `theme-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840edd2ce408322a564a09251ab574a