### PR TITLE
Fix sticky header script errors

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -382,7 +382,6 @@
       <script src="{{ 'cart-drawer.js' | asset_url }}" defer="defer"></script>
     {%- endif -%}
 
-    <script src="{{ 'global.js' | asset_url }}" defer="defer"></script>
     <script src="{{ 'rave-custom.js' | asset_url }}" defer="defer"></script>
 
     {% comment %} Klaviyo Back In Stock Snippet with Rave styling {% endcomment %}

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -474,7 +474,9 @@
 
     closeSearchModal() {
       this.searchModal = this.searchModal || this.header.querySelector('details-modal');
-      this.searchModal.close(false);
+      if (this.searchModal && typeof this.searchModal.close === 'function') {
+        this.searchModal.close(false);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- avoid error when header has no search modal
- remove duplicate `global.js` include

## Testing
- `npx prettier --check sections/header.liquid layout/theme.liquid` *(fails: No parser could be inferred)*

------
https://chatgpt.com/codex/tasks/task_e_6840f1b5599c8322bf53bfc3a4029344