### PR TITLE
Use visibility-hidden for recommendations

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -1134,7 +1134,7 @@ class ProductRecommendations extends HTMLElement {
   }
 
   connectedCallback() {
-    this.hidden = true;
+    this.classList.add('visibility-hidden');
     this.initializeRecommendations(this.dataset.productId);
   }
 
@@ -1164,7 +1164,7 @@ class ProductRecommendations extends HTMLElement {
 
         if (recommendations?.innerHTML.trim().length) {
           this.innerHTML = recommendations.innerHTML;
-          this.hidden = false;
+          this.classList.remove('visibility-hidden');
           if (html.querySelector('.grid__item')) {
             this.classList.add('product-recommendations--loaded');
           }

--- a/assets/rave-custom.css
+++ b/assets/rave-custom.css
@@ -45,6 +45,9 @@ header.header {
 }
 */
 
+product-recommendations.visibility-hidden {
+  min-height: 5rem;
+}
 /* 3. Component/Section Specific Styles will be added below as developed */
 
 /* == HOMEPAGE HERO == */

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -514,11 +514,10 @@
                 {%- endif -%}
               {%- when 'complementary' -%}
                 <product-recommendations
-                  class="complementary-products quick-add-hidden{% if block.settings.make_collapsible_row %} is-accordion{% endif %}{% if block.settings.enable_quick_add %} complementary-products-contains-quick-add{% endif %}"
+                  class="complementary-products quick-add-hidden visibility-hidden{% if block.settings.make_collapsible_row %} is-accordion{% endif %}{% if block.settings.enable_quick_add %} complementary-products-contains-quick-add{% endif %}"
                   data-url="{{ routes.product_recommendations_url }}?limit={{ block.settings.product_list_limit }}&intent=complementary"
                   data-section-id="{{ section.id }}"
                   data-product-id="{{ product.id }}"
-                  hidden
                 >
                   {%- if recommendations.performed and recommendations.products_count > 0 -%}
                     <aside

--- a/sections/related-products.liquid
+++ b/sections/related-products.liquid
@@ -22,7 +22,7 @@
 
 <div class="color-{{ section.settings.color_scheme }} gradient">
   <product-recommendations
-    class="related-products page-width section-{{ section.id }}-padding isolate{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}"
+    class="related-products page-width section-{{ section.id }}-padding isolate visibility-hidden{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}"
     data-url="{{ routes.product_recommendations_url }}?limit={{ section.settings.products_to_show }}"
     data-section-id="{{ section.id }}"
     data-product-id="{{ product.id }}"


### PR DESCRIPTION
## Summary
- hide `<product-recommendations>` with `visibility-hidden`
- reveal recommendations after load
- keep minimal height while hidden
- include `visibility-hidden` on product pages

## Testing
- `npx prettier -w assets/global.js`
- `npx prettier -w assets/rave-custom.css`
- `npx prettier -w sections/main-product.liquid` *(fails: No parser could be inferred)*
- `npx prettier -w sections/related-products.liquid` *(fails: No parser could be inferred)*
- `theme-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f5123f688322b32b7c0317fb8d32