### PR TITLE
Gate product recommendation errors

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -1173,7 +1173,7 @@ class ProductRecommendations extends HTMLElement {
         }
       })
       .catch((e) => {
-        console.error(e);
+        if (Shopify.designMode) console.error(e);
         this.remove();
       });
   }


### PR DESCRIPTION
## Summary
- gate `console.error` in product recommendations so logs only appear in Shopify editor

## Testing
- `npx prettier -w assets/global.js`

------
https://chatgpt.com/codex/tasks/task_e_6840f516e4f08322b9ea6d0780899ad0